### PR TITLE
Use HTTPs instead of HTTP

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
         </repository>
         <repository>
             <id>placeholderapi</id>
-            <url>http://repo.extendedclip.com/content/repositories/placeholderapi/</url>
+            <url>https://repo.extendedclip.com/content/repositories/placeholderapi/</url>
         </repository>
         <repository>
             <id>unnamed-snapshots</id>


### PR DESCRIPTION
It cannot be compiled with newer versions of Maven if it uses HTTP