### PR TITLE
Update adventure-platform-bukkit dependency and setup GitHub actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,15 @@
+name: 'build'
+on: ['pull_request', 'push']
+jobs:
+  build:
+    if: ${{ github.event_name != 'pull_request' || github.repository != github.event.pull_request.head.repo.full_name }}
+    runs-on: 'ubuntu-latest'
+    steps:
+      - name: 'checkout repo'
+        uses: 'actions/checkout@v2'
+      - name: 'setup JDK'
+        uses: 'actions/setup-java@v1'
+        with:
+          java-version: 17
+      - name: 'build'
+        run: 'mvn clean package'

--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,7 @@
         <dependency>
             <groupId>net.kyori</groupId>
             <artifactId>adventure-platform-bukkit</artifactId>
-            <version>4.0.0-SNAPSHOT</version>
+            <version>4.0.0</version>
             <scope>compile</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
- Update adventure-platform-bukkit from `4.0.0-SNAPSHOT` to `4.0.0` as it wasn't found in Maven Central repository
- Setup GitHub actions 'build' workflow to ensure builds are reproducible